### PR TITLE
Fixed inheritance separator list for TypeBuilderBase<T>

### DIFF
--- a/src/VaVare/Builders/Base/TypeBuilderBase.cs
+++ b/src/VaVare/Builders/Base/TypeBuilderBase.cs
@@ -185,7 +185,7 @@ namespace VaVare.Builders.Base
             return BaseList(
                 SeparatedList<BaseTypeSyntax>(
                     _inheritance.Select(i => SimpleBaseType(TypeGenerator.Create(i))), 
-                    _inheritance.Select(i => Token(SyntaxKind.CommaToken))));
+                    _inheritance.Skip(1).Select(i => Token(SyntaxKind.CommaToken))));
         }
     }
 }


### PR DESCRIPTION
* Skip first inheritance for separator tokens, as there should always be one separator token less than inheritance tokens